### PR TITLE
Remove low battery warning

### DIFF
--- a/software/badge.js
+++ b/software/badge.js
@@ -187,6 +187,7 @@ Badge.badge = () => {
       .toISOString()
       .split("T")[1]
       .substr(0, 5);
+    //if (E.getAnalogVRef() < 3.25) timeStr += " LOW BATTERY"; //Disabled Low Batt warning, review in proto2 board
     g.drawString(timeStr, 0, 59);
     // now write to the screen
     g.flip();

--- a/software/badge.js
+++ b/software/badge.js
@@ -187,7 +187,6 @@ Badge.badge = () => {
       .toISOString()
       .split("T")[1]
       .substr(0, 5);
-    if (E.getAnalogVRef() < 3.25) timeStr += " LOW BATTERY";
     g.drawString(timeStr, 0, 59);
     // now write to the screen
     g.flip();


### PR DESCRIPTION
I'm powering off USB and the low battery warning just kinda flashes on and off all the time. I am not sure it's helpful so I'm suggesting we remove it.